### PR TITLE
fix table des matières vide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 lockpicking.pdf:
 	pdflatex lockpicking.tex
+	pdflatex lockpicking.tex
 
 lockpicking.zip: lockpicking.pdf
 	# TODO: avoid zipbomb


### PR DESCRIPTION
LaTeX a besoin de plusieurs passes avant d'atteindre un état stable. On lance arbitrairement deux compilations pour avoir (au moins) la table des matières.
